### PR TITLE
Update disagg proxy server for json I/O

### DIFF
--- a/examples/offline_inference/disaggrated-prefill-v1/run_server.sh
+++ b/examples/offline_inference/disaggrated-prefill-v1/run_server.sh
@@ -15,7 +15,7 @@ if [[ $1 == "producer" ]]; then
         VLLM_WORKER_MULTIPROC_METHOD=spawn \
         CUDA_VISIBLE_DEVICES=0 \
         vllm serve meta-llama/Llama-3.1-8B-Instruct \
-        --port 9100 \
+        --port 9101 \
         --disable-log-requests \
         --max-num-seqs 50 \
         --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_producer","kv_connector_extra_config": {}}'
@@ -33,7 +33,7 @@ elif [[ $1 == "consumer" ]]; then
         VLLM_WORKER_MULTIPROC_METHOD=spawn \
         CUDA_VISIBLE_DEVICES=1 \
         vllm serve meta-llama/Llama-3.1-8B-Instruct \
-        --port 9200 \
+        --port 9201 \
         --disable-log-requests \
         --max-num-seqs 50 \
         --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_consumer","kv_connector_extra_config": {}}'


### PR DESCRIPTION
Small update to disagg_prefill_proxy_server.py to allow testing with `lm_eval`

With this change I can hit the proxy server with the following:
```
lm_eval --model local-completions --tasks gsm8k --model_args model=meta-llama/Llama-3.1-8B-Instruct,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=5,max_retries=3,tokenized_requests=False --limit 40
```

Result:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.575|±  |0.0792|
|     |       |strict-match    |     5|exact_match|↑  |0.575|±  |0.0792|
```